### PR TITLE
Disable selinux for docker so it starts successfully

### DIFF
--- a/amazon_k8s_centos_7_master.sh
+++ b/amazon_k8s_centos_7_master.sh
@@ -6,6 +6,7 @@
 
 # Disabling SELinux is not recommended and will be fixed later.
 sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo sed -i 's/--selinux-enabled /--selinux-enabled=false /g' /etc/sysconfig/docker
 sudo setenforce 0
 
 sudo rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg

--- a/amazon_k8s_centos_7_node.sh
+++ b/amazon_k8s_centos_7_node.sh
@@ -7,6 +7,7 @@
 
 # Disabling SELinux is not recommended and will be fixed later.
 sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo sed -i 's/--selinux-enabled /--selinux-enabled=false /g' /etc/sysconfig/docker
 sudo setenforce 0
 
 sudo rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg


### PR DESCRIPTION
Before: 
```
-- Unit docker.service has begun starting up.
Mar 30 18:25:41 ip-10-0-0-223 dockerd-current[10094]: time="2018-03-30T18:25:41.647843032Z" level=warning msg="could not change group /var/run/docker.sock to docker: group docker not found"
Mar 30 18:25:41 ip-10-0-0-223 dockerd-current[10094]: time="2018-03-30T18:25:41.648803658Z" level=info msg="libcontainerd: new containerd process, pid: 10101"
Mar 30 18:25:42 ip-10-0-0-223 dockerd-current[10094]: Error starting daemon: SELinux is not supported with the overlay2 graph driver on this kernel. Either boot into a newer kernel or disable selinux in docker (--selinux-enabled=false)
Mar 30 18:25:42 ip-10-0-0-223 systemd[1]: docker.service: main process exited, code=exited, status=1/FAILURE
Mar 30 18:25:42 ip-10-0-0-223 systemd[1]: Failed to start Docker Application Container Engine.
-- Subject: Unit docker.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- Unit docker.service has failed.
--
-- The result is failed.
```