### PR TITLE
amazon,packet: bind kubernetes version to 1.10.4 (master)

### DIFF
--- a/amazon_k8s_centos_7_master.sh
+++ b/amazon_k8s_centos_7_master.sh
@@ -4,6 +4,10 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
+
 # Disabling SELinux is not recommended and will be fixed later.
 sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
 sudo sed -i 's/--selinux-enabled /--selinux-enabled=false /g' /etc/sysconfig/docker
@@ -28,8 +32,9 @@ sudo yum install -y \
      docker \
      socat \
      ebtables \
-     kubelet \
-     kubeadm \
+     kubelet-${KUBERNETES_VERSION}-0 \
+     kubeadm-${KUBERNETES_VERSION}-0 \
+     kubernetes-cni-${KUBERNETES_CNI}-0 \
      cloud-utils \
      epel-release
 
@@ -62,6 +67,7 @@ apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 cloudProvider: aws
 token: ${TOKEN}
+kubernetesVersion: ${KUBERNETES_VERSION}
 nodeName: ${HOSTNAME}
 api:
   advertiseAddress: ${PUBLICIP}

--- a/amazon_k8s_centos_7_node.sh
+++ b/amazon_k8s_centos_7_node.sh
@@ -4,6 +4,9 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 # Disabling SELinux is not recommended and will be fixed later.
 sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
@@ -31,8 +34,9 @@ sudo yum install -y \
      docker \
      socat \
      ebtables \
-     kubelet \
-     kubeadm \
+     kubelet-${KUBERNETES_VERSION}-0 \
+     kubeadm-${KUBERNETES_VERSION}-0 \
+     kubernetes-cni-${KUBERNETES_CNI}-0 \
      epel-release
 
 # jq needs its own special yum install as it depends on epel-release

--- a/amazon_k8s_debian_stretch_master.sh
+++ b/amazon_k8s_debian_stretch_master.sh
@@ -5,7 +5,8 @@
 # ------------------------------------------------------------------------------------------------------------------------
 
 # Specify the Kubernetes version to use
-KUBERNETES_VERSION="1.9.0"
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 apt-get update -y
 apt-get install -y \
@@ -37,8 +38,9 @@ systemctl start docker
 
 apt-get update -y
 apt-get install -y \
-    kubelet \
+    kubelet=${KUBERNETES_VERSION}-00 \
     kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     kubectl
 
 PUBLICIP=$(ec2metadata --public-ipv4 | cut -d " " -f 2)

--- a/amazon_k8s_debian_stretch_node.sh
+++ b/amazon_k8s_debian_stretch_node.sh
@@ -5,7 +5,8 @@
 # ------------------------------------------------------------------------------------------------------------------------
 
 # Specify the Kubernetes version to use
-KUBERNETES_VERSION="1.9.0"
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 apt-get update -y
 apt-get install -y \
@@ -33,7 +34,11 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
 apt-get update -y
-apt-get install -y kubelet kubeadm kubectl
+apt-get install -y \
+	kubelet=${KUBERNETES_VERSION}-00 \
+	kubeadm=${KUBERNETES_VERSION}-00 \
+	kubernetes-cni=${KUBERNETES_CNI}-00 \
+	kubectl
 
 systemctl enable docker
 systemctl start docker

--- a/amazon_k8s_ubuntu_16.04_master.sh
+++ b/amazon_k8s_ubuntu_16.04_master.sh
@@ -4,8 +4,9 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-# Specify the Kubernetes version to use
-KUBERNETES_VERSION="1.8.4"
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
@@ -27,8 +28,9 @@ apt-get install -y \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
+    kubelet=${KUBERNETES_VERSION}-00 \
     kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     cloud-utils \
     jq
 

--- a/amazon_k8s_ubuntu_16.04_node.sh
+++ b/amazon_k8s_ubuntu_16.04_node.sh
@@ -4,8 +4,9 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-# Specify the Kubernetes version to use
-KUBERNETES_VERSION="1.8.4"
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
@@ -27,8 +28,9 @@ apt-get install -y \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
+    kubelet=${KUBERNETES_VERSION}-00 \
     kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     jq
 
 systemctl enable docker

--- a/packet_k8s_ubuntu_16.04_master.sh
+++ b/packet_k8s_ubuntu_16.04_master.sh
@@ -4,6 +4,10 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
+
 # order is important:
 # 1. update
 # 2. install apt-transport-https
@@ -24,8 +28,9 @@ apt-get install -y \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
-    kubeadm=1.7.0-00 \
+    kubelet=${KUBERNETES_VERSION}-00 \
+    kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     cloud-utils \
     jq
 
@@ -42,7 +47,7 @@ TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig'
 PORT=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.kubernetesAPI.port | tonumber')
 
 kubeadm reset
-kubeadm init --apiserver-bind-port ${PORT} --token ${TOKEN}  --apiserver-advertise-address ${PUBLICIP} --apiserver-cert-extra-sans ${PUBLICIP} ${PRIVATEIP}
+kubeadm init --apiserver-bind-port ${PORT} --token ${TOKEN}  --apiserver-advertise-address ${PUBLICIP} --apiserver-cert-extra-sans ${PUBLICIP} ${PRIVATEIP} --kubernetes-version ${KUBERNETES_VERSION}
 
 # Thanks Kelsey :)
 kubectl apply \

--- a/packet_k8s_ubuntu_16.04_node.sh
+++ b/packet_k8s_ubuntu_16.04_node.sh
@@ -4,6 +4,9 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.10.4"
+KUBERNETES_CNI="0.6.0"
 
 # order is important:
 # 1. update
@@ -25,8 +28,9 @@ apt-get install -y \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
-    kubeadm=1.7.0-00 \
+    kubelet=${KUBERNETES_VERSION}-00 \
+    kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     jq
 
 systemctl enable docker


### PR DESCRIPTION
Closes kubicorn/kubicorn#627

As stated in kubernetes/kubeadm#612, we're required to bind `kubelet` to specific version using our installation mechanism (`apt-get` and `yum`) in our scripts, because `kubeadm` doesn't install `kubelet` for us. This also requires us to bind to specific `kubernetes-cni` version, otherwise `apt-get install`/`yum install` will fail.

This PR updates all bootstrap scripts to use this mechanism. GCE and DO scripts are already using it.

This is not tested, so it's recommended to test this before merging.