### PR TITLE
Remove kubeadm pinning

### DIFF
--- a/packet_k8s_ubuntu_16.04_master.sh
+++ b/packet_k8s_ubuntu_16.04_master.sh
@@ -25,7 +25,7 @@ apt-get install -y \
     docker.io \
     apt-transport-https \
     kubelet \
-    kubeadm=1.7.0-00 \
+    kubeadm \
     cloud-utils \
     jq
 

--- a/packet_k8s_ubuntu_16.04_node.sh
+++ b/packet_k8s_ubuntu_16.04_node.sh
@@ -26,7 +26,7 @@ apt-get install -y \
     docker.io \
     apt-transport-https \
     kubelet \
-    kubeadm=1.7.0-00 \
+    kubeadm \
     jq
 
 systemctl enable docker


### PR DESCRIPTION
kubeadm is pinned to 1.7, removing to keep the profiles generic / working