### PR TITLE
Delay kubeadm join on nodes until master port is listening

### DIFF
--- a/amazon_k8s_debian_stretch_node.sh
+++ b/amazon_k8s_debian_stretch_node.sh
@@ -8,6 +8,10 @@
 KUBERNETES_VERSION="1.10.4"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
 apt-get update -y
 apt-get install -y \
     socat \
@@ -48,5 +52,23 @@ MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig
 HOSTNAME=$(hostname -f)
 
 
+# Reset before joining
 kubeadm reset
-kubeadm join --discovery-token-unsafe-skip-ca-verification --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} 
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi

--- a/amazon_k8s_ubuntu_16.04_node.sh
+++ b/amazon_k8s_ubuntu_16.04_node.sh
@@ -8,6 +8,10 @@
 KUBERNETES_VERSION="1.10.4"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
 sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
@@ -45,5 +49,23 @@ systemctl restart kubelet.service
 # Necessary for joining a cluster with the AWS information
 HOSTNAME=$(hostname -f)
 
+# Reset before joining
 kubeadm reset
-kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi

--- a/digitalocean_k8s_centos_7_node.sh
+++ b/digitalocean_k8s_centos_7_node.sh
@@ -8,6 +8,11 @@
 KUBERNETES_VERSION="1.9.2"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
+
 # Import GPG keys and add repository entries for Kuberenetes.
 rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg
 rpm --import https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
@@ -54,6 +59,23 @@ systemctl restart kubelet
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDMASTER')
 
-# Join node a cluster.
+# Reset before joining
 kubeadm reset
-kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi

--- a/digitalocean_k8s_ubuntu_16.04_node.sh
+++ b/digitalocean_k8s_ubuntu_16.04_node.sh
@@ -60,7 +60,7 @@ systemctl restart kubelet
 TOKEN=$(< /etc/kubicorn/cluster.json jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(< /etc/kubicorn/cluster.json jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDMASTER')
 
-# Join node a cluster.
+# Reset before joining
 kubeadm reset --force
 
 # Delay kubeadm join until master is ready
@@ -72,10 +72,11 @@ while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
   response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
 done
 
+# Join the cluster
 if [ "${response}" -ne "200" ]; then
   echo "Maximum attempts reached, giving up"
   exit 1
 else
-  echo "Master seems to be up and running. Joining it..."
+  echo "Master seems to be up and running. Joining the node to the cluster..."
   kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
 fi

--- a/google_compute_k8s_ubuntu_16.04_node.sh
+++ b/google_compute_k8s_ubuntu_16.04_node.sh
@@ -8,6 +8,10 @@
 KUBERNETES_VERSION="1.9.2"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
 # Obtain metadata.
 PRIVATEIP=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip"`
 PUBLICIP=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"`
@@ -40,6 +44,23 @@ systemctl start docker
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDMASTER')
 
-# Join node a cluster.
+# Reset before joining
 kubeadm reset
-kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi

--- a/ovh_k8s_ubuntu_16.04_node.sh
+++ b/ovh_k8s_ubuntu_16.04_node.sh
@@ -8,6 +8,10 @@
 KUBERNETES_VERSION="1.9.2"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
 # Acquire private IP address
 cat << EOF >> "/etc/network/interfaces.d/50-cloud-init.cfg"
 auto ens4
@@ -53,6 +57,23 @@ systemctl restart kubelet
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDMASTER')
 
-# Join node a cluster.
+# Reset before joining
 kubeadm reset
-kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi

--- a/packet_k8s_ubuntu_16.04_node.sh
+++ b/packet_k8s_ubuntu_16.04_node.sh
@@ -8,6 +8,10 @@
 KUBERNETES_VERSION="1.10.4"
 KUBERNETES_CNI="0.6.0"
 
+# Controls delay before attempting to join the master
+MAX_ATTEMPTS=50
+REATTEMPT_INTERVAL_SECONDS=30
+
 # order is important:
 # 1. update
 # 2. install apt-transport-https
@@ -46,5 +50,23 @@ MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig
 systemctl daemon-reload
 systemctl restart kubelet.service
 
+# Reset before joining
 kubeadm reset
-kubeadm join --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification
+
+# Delay kubeadm join until master is ready
+attempts=0
+response=000
+while [ "${response}" -ne "200" ] && [ $(( attempts++ )) -lt $MAX_ATTEMPTS ]; do
+  echo "Waiting for master to be ready(${MASTER})..."
+  sleep $REATTEMPT_INTERVAL_SECONDS
+  response=$(curl --write-out "%{http_code}" --output /dev/null --silent --connect-timeout 10 -k "https://${MASTER}/healthz" || true)
+done
+
+# Join the cluster
+if [ "${response}" -ne "200" ]; then
+  echo "Maximum attempts reached, giving up"
+  exit 1
+else
+  echo "Master seems to be up and running. Joining the node to the cluster..."
+  kubeadm join --node-name "${HOSTNAME}" --token "${TOKEN}" "${MASTER}" --discovery-token-unsafe-skip-ca-verification
+fi


### PR DESCRIPTION
As discussed in #20, applying the same delay logic (where a node would wait for its master to be ready before attempting a kubeadm join) to the rest of bootstrap scripts.

These scripts haven't been tested (I have only tested `digitalocean_k8s_centos_7_node.sh` one and the logic seems to be working but I am facing some kind of issue with master not booting up (unrelated to this PR) so the node keeps waiting and gives up at some point as expected). Logic is simple so should any issue arise it should be easily fixed (for instance if curl needs to be installed)