### PR TITLE
do: set cluster name for ubuntu clusters

### DIFF
--- a/digitalocean_k8s_ubuntu_16.04_master.sh
+++ b/digitalocean_k8s_ubuntu_16.04_master.sh
@@ -53,6 +53,7 @@ systemctl daemon-reload
 systemctl restart kubelet
 
 # Parse kubicorn configuration file.
+CLUSTER_NAME=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.metadata.name')
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDTOKEN')
 PORT=$(cat /etc/kubicorn/cluster.json | jq -r '.clusterAPI.spec.providerConfig' | jq -r '.values.itemMap.INJECTEDPORT | tonumber')
 
@@ -64,6 +65,7 @@ kind: MasterConfiguration
 token: ${TOKEN}
 kubernetesVersion: ${KUBERNETES_VERSION}
 nodeName: ${HOSTNAME}
+clusterName: ${CLUSTER_NAME}
 api:
   advertiseAddress: ${PUBLICIP}
   bindPort: ${PORT}


### PR DESCRIPTION
As of Kubernetes 1.11 (https://github.com/kubernetes/kubernetes/pull/60852) it is possible to set cluster name to be used instead of `kubernetes-admin@kubernetes`.

We've already switched to 1.11 for DO Ubuntu cluster and this PR adds the `clusterName` to `kubeadm` configuration file.

With this change in place, clusters are called `kubernetes-admin@<cluster-name>`.